### PR TITLE
调整内容关于 Calcit, Aya, Cicada

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 | 语言名称 | 是否开源 | 作者 | 简介 |
 |---|---|---|---|
 | [凹语言™](https://wa-lang.org) | 开源 | [柴树杉](https://github.com/chai2010)/[丁尔男](https://github.com/3dgen)/[史斌](https://github.com/benshi001) | 披着 Go 和 Rust 语法外衣的 C++ 语言 |
+| [Aya](https://github.com/aya-prover/aya-dev/) | 开源 | [千里冰封](https://github.com/ice1000)等 | 一种编程语言和证明助手，专为形式化数学和类型导向编程而设计。 |
 | [仓颉](https://baike.baidu.com/item/%E4%BB%93%E9%A2%89/58954708) | ?/未发布 | 华为公司 | 面向HarmonyOS的编程语言，为鸿蒙生态基础设施建设补上最后一环。
-| [Calcit](https://calcit-lang.org/) | 开源 | 题叶 | 类似 ClojureScript，可解释执行（解释器为Rust实现），或编译为 JavaScript ES modul。
+| [Calcit](https://calcit-lang.org/) | 开源 | [题叶](https://github.com/tiye) | 缩进语法的 Clojure 方言，基于 Rust 解释执行，支持编译为 `*.mjs` 使用。 |
+| [Cicada(蝉语)](https://github.com/cicada-lang/cicada) | 开源 | [谢宇恒](https://github.com/xieyuheng) | 一门依赖类型编程语言，一个交互式定理证明器。 |
 | [CovScript](https://unicov.cn/covscript/) | ? | 李登淳 | 脚本编程语言 |
 | [Go+](https://github.com/goplus/gop) | 开源 | [许式伟](https://github.com/xushiwei) | 基于 Go 语言扩展的语言，Go 语言实现 |
 | [HVML(呼噜猫)](https://hvml.fmsoft.cn/) | 开源 | [魏永明](https://github.com/VincentWei) | 应用编程语言
-| [九章编程](https://jiuzhang.cirru.org/) | 开源 | 题叶 | 类似文言的实验性语言
 | [KCL](https://github.com/KusionStack/KCLVM) | 开源 | 蚂蚁集团| [KusionStack](https://github.com/KusionStack/kusion) 云原生配置技术栈项目提供的配置策略语言，Rust 语言实现 |
 | [木兰](https://gitee.com/MulanRevive/mulan-rework) | ? | 中科院/吴烜 | 基于Python的编程语言
 | [OpenBlock](https://gitee.com/openblock/openblock) | 开源 | 杜天微 | 简单易学的、面向业务的图形化脚本语言，开放原子开源基金会孵化项目 |

--- a/_examples/hello-calcit/.gitignore
+++ b/_examples/hello-calcit/.gitignore
@@ -1,0 +1,7 @@
+
+.compact-inc.cirru
+compact.cirru
+js-out/
+.calcit-error.cirru
+
+node_modules/

--- a/_examples/hello-calcit/README.md
+++ b/_examples/hello-calcit/README.md
@@ -1,0 +1,60 @@
+## Calcit 语言
+
+欢迎尝试 Calcit 语言. 嫌拗口可以叫"方解石"或者"方解"语言.
+
+[![](https://cdn.tiye.me/logo/calcit.png)](http://calcit-lang.org/)
+
+### 编辑器说明
+
+Calcit 语言设计中, 主要使用网页编辑器来进行开发, 可能上手较难, 参考[Calcit 脚手架](https://github.com/calcit-lang/calcit-workflow).
+
+本示例对应[最小化脚手架](https://github.com/calcit-lang/minimal-calcit), Calcit 提供了对纯文本编辑器编码的支持, 需要多运行一个命令先对代码进行合并处理, 然后执行.
+
+### 用法
+
+1. 安装 Calcit.
+
+先安装 Rust, 再运行:
+
+```bash
+cargo install calcit
+```
+
+2. 运行程序.
+
+```bash
+$ bundle_calcit -1 && cr -1
+file created at ./compact.cirru
+Calling main function: 10
+Calling lib
+took 0.238ms: nil
+```
+
+```
+.
+├── README.md
+├── compact.cirru # `bundle_calcit` 合并后的文件
+├── package.cirru # `bundle_calcit` 使用的配置信息
+└── src # 纯文本编辑器编码的内容
+    ├── lib.cirru
+    └── main.cirru
+```
+
+### 编译到 JavaScript
+
+Calcit 会编译代码到 `js-out/*.mjs`, 需要创建一个额外的 `main.mjs` 作为入口文件:
+
+```js
+import { main_$x_ } from "./js-out/app.main.mjs";
+main_$x_();
+```
+
+运行前需要安装一些核心函数的模块, 最后用 Node.js(注意版本要有 ES Modules 支持)运行:
+
+```bash
+cr -1 --emit-js
+yarn add @calcit/procs
+node main.mjs
+```
+
+或者也可以自己再安装 Vite 配合 HTML 页面运行.

--- a/_examples/hello-calcit/package.cirru
+++ b/_examples/hello-calcit/package.cirru
@@ -1,0 +1,6 @@
+
+{}
+  :package |app
+  :modules $ []
+  :init-fn |app.main/main!
+  :reload-fn |app.main/main!

--- a/_examples/hello-calcit/src/lib.cirru
+++ b/_examples/hello-calcit/src/lib.cirru
@@ -1,0 +1,5 @@
+
+ns app.lib
+
+defn call-lib ()
+  println "|Calling lib"

--- a/_examples/hello-calcit/src/main.cirru
+++ b/_examples/hello-calcit/src/main.cirru
@@ -1,0 +1,8 @@
+
+ns app.main
+  :require
+    app.lib :refer $ call-lib
+
+defn main! ()
+  println "|Calling main function:" $ + 1 2 3 4
+  call-lib


### PR DESCRIPTION
Calcit 描述优化. Calcit 用的存储格式是 Cirru, 其实是数据格式, 场景比较多所以可能存在混淆, GitHub https://api.github.com/search/repositories?q=language:Cirru 当中应该超过半数是 Calcit/Calcit-js 项目. 也算正经在用的语言了.

九章属于玩具语言, 移除.

另两门语言描述我是从官网摘的然后翻译了 @ice1000 @xieyuheng